### PR TITLE
Add milliseconds precision to crash info

### DIFF
--- a/Source/KSCrash/Recording/KSCrashReport.c
+++ b/Source/KSCrash/Recording/KSCrashReport.c
@@ -56,7 +56,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
+#include <sys/time.h>
 
 // ============================================================================
 #pragma mark - Constants -
@@ -1530,10 +1530,14 @@ static void writeReportInfo(const KSCrashReportWriter* const writer,
 {
     writer->beginObject(writer, key);
     {
+        struct timeval tp;
+        gettimeofday(&tp, NULL);
+        long int microseconds = tp.tv_sec * 1000000 + tp.tv_usec;
+        
         writer->addStringElement(writer, KSCrashField_Version, KSCRASH_REPORT_VERSION);
         writer->addStringElement(writer, KSCrashField_ID, reportID);
         writer->addStringElement(writer, KSCrashField_ProcessName, processName);
-        writer->addIntegerElement(writer, KSCrashField_Timestamp, time(NULL));
+        writer->addIntegerElement(writer, KSCrashField_Timestamp, microseconds);
         writer->addStringElement(writer, KSCrashField_Type, type);
     }
     writer->endContainer(writer);

--- a/Source/KSCrash/Recording/KSCrashReportFixer.c
+++ b/Source/KSCrash/Recording/KSCrashReportFixer.c
@@ -160,8 +160,8 @@ static int onIntegerElement(const char* const name,
     int result = KSJSON_OK;
     if(shouldFixDate(context, name))
     {
-        char buffer[21];
-        ksdate_utcStringFromTimestamp((time_t)value, buffer);
+        char buffer[28];
+        ksdate_utcStringFromMicroseconds(value, buffer);
 
         result = ksjson_addStringElement(context->encodeContext, name, buffer, (int)strlen(buffer));
     }

--- a/Source/KSCrash/Recording/Tools/KSDate.c
+++ b/Source/KSCrash/Recording/Tools/KSDate.c
@@ -38,3 +38,15 @@ void ksdate_utcStringFromTimestamp(time_t timestamp, char* buffer21Chars)
              result.tm_min,
              result.tm_sec);
 }
+
+void ksdate_utcStringFromMicroseconds(int64_t microseconds, char* buffer28Chars)
+{
+    struct tm result = {0};
+    time_t curtime = (time_t)(microseconds / 1000000);
+    long micros = (time_t)(microseconds % 1000000);
+    
+    gmtime_r(&curtime, &result);
+    char buf[20];
+    strftime(buf, 20,"%FT%T", &result);
+    sprintf(buffer28Chars, "%s.%06ldZ", buf, micros);
+}

--- a/Source/KSCrash/Recording/Tools/KSDate.h
+++ b/Source/KSCrash/Recording/Tools/KSDate.h
@@ -40,6 +40,14 @@ extern "C" {
  */
 void ksdate_utcStringFromTimestamp(time_t timestamp, char* buffer21Chars);
 
+/** Convert microseconds returned from `gettimeofday` to an RFC3339 string representation.
+ *
+ * @param microseconds The microseconds to convert.
+ *
+ * @param buffer28Chars A buffer of at least 28 chars to hold the RFC3339 date string with milliseconds precision.
+ */
+void ksdate_utcStringFromMicroseconds(int64_t microseconds, char* buffer28Chars);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
+++ b/Source/KSCrash/Reporting/Filters/KSCrashReportFilterAppleFmt.m
@@ -120,7 +120,7 @@ static NSDictionary* g_registerOrders;
 
     g_rfc3339DateFormatter = [[NSDateFormatter alloc] init];
     [g_rfc3339DateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
-    [g_rfc3339DateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+    [g_rfc3339DateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSSSS'Z'"];
     [g_rfc3339DateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
 
     NSArray* armOrder = [NSArray arrayWithObjects:


### PR DESCRIPTION
Store milliseconds from January 1, 1970 as returned from `gettimeofday()` in KSCrashField_Timestamp  instead of the seconds returned from `time()`.
It is more useful when comparing with other logs from the app (Console in OSX)